### PR TITLE
Added some more compatiblity information

### DIFF
--- a/data/blocking/options/csp.json
+++ b/data/blocking/options/csp.json
@@ -15,7 +15,7 @@
               "version_added": true
             },
             "ublockorigin": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {

--- a/data/blocking/options/font.json
+++ b/data/blocking/options/font.json
@@ -9,7 +9,7 @@
               "version_added": null
             },
             "adblockplus": {
-              "version_added": null
+              "version_added": true
             },
             "adguard": {
               "version_added": true

--- a/data/blocking/options/media.json
+++ b/data/blocking/options/media.json
@@ -9,7 +9,7 @@
               "version_added": null
             },
             "adblockplus": {
-              "version_added": null
+              "version_added": true
             },
             "adguard": {
               "version_added": true

--- a/data/blocking/options/object-subrequest.json
+++ b/data/blocking/options/object-subrequest.json
@@ -9,10 +9,16 @@
               "version_added": null
             },
             "adblockplus": {
-              "version_added": null
+              "version_added": true,
+              "notes": [
+                "On browsers other than Firefox this option also matches requests of the type OBJECT."
+              ]
             },
             "adguard": {
-              "version_added": true
+              "version_added": true,
+              "notes": [
+                "On browsers other than Firefox this option also matches requests of the type OBJECT."
+              ]
             },
             "ublockorigin": {
               "version_added": null

--- a/data/blocking/options/object.json
+++ b/data/blocking/options/object.json
@@ -9,10 +9,16 @@
               "version_added": null
             },
             "adblockplus": {
-              "version_added": null
+              "version_added": true,
+              "notes": [
+                "On browsers other than Firefox this option also matches requests of the type OBJECT_SUBREQUEST."
+              ]
             },
             "adguard": {
-              "version_added": true
+              "version_added": true,
+              "notes": [
+                "On browsers other than Firefox this option also matches requests of the type OBJECT_SUBREQUEST."
+              ]
             },
             "ublockorigin": {
               "version_added": null

--- a/data/blocking/options/other.json
+++ b/data/blocking/options/other.json
@@ -9,7 +9,7 @@
               "version_added": null
             },
             "adblockplus": {
-              "version_added": null
+              "version_added": true
             },
             "adguard": {
               "version_added": null

--- a/data/blocking/options/rewrite.json
+++ b/data/blocking/options/rewrite.json
@@ -15,7 +15,7 @@
               "version_added": false
             },
             "ublockorigin": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {

--- a/data/blocking/options/websocket.json
+++ b/data/blocking/options/websocket.json
@@ -9,7 +9,7 @@
               "version_added": true
             },
             "adblockplus": {
-              "version_added": "1.12.2"
+              "version_added": "2.8 (1.12.2)"
             },
             "adguard": {
               "version_added": null


### PR DESCRIPTION
These are the information I can add with high confidence from the top of my head.

Note: I didn't touch compatibility information of AdBlock, since AdBlock for Chrome, Firefox and Microsoft Edge are separate implementations. AdBlock for Chrome is based on Adblock Plus, and the features map one-to-one, AdBlock for Firefox and Microsoft Edge, however, are two separate forks of the original AdBlock code base. Any suggestion how to deal with that?